### PR TITLE
handle of visibility timeout directly from the queue settings if none…

### DIFF
--- a/consumer/sqs_test.go
+++ b/consumer/sqs_test.go
@@ -102,7 +102,7 @@ func TestNewSQSWorker(t *testing.T) {
 					Queue:               "queue",
 					Concurrency:         DefaultConcurrency,
 					MaxNumberOfMessages: DefaultMaxNumberOfMessages,
-					VisibilityTimeout:   DefaultVisibilityTimeout,
+					VisibilityTimeout:   QueueVisibilityTimeout,
 					WaitTimeSeconds:     DefaultWaitTimeSeconds,
 				},
 				sqs: svc,


### PR DESCRIPTION
I've removed the default configuration, if not provided, for the visibility timeout parameter. If not specified it will get the visibility timeout specified from the sqs settings.

![image](https://user-images.githubusercontent.com/1730821/89172074-5793f300-d582-11ea-88ae-e77ba334dce1.png)
